### PR TITLE
Downgrade .NET SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.203",
+    "version": "7.0.100",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/TodoApp/TodoApp.csproj
+++ b/src/TodoApp/TodoApp.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="7.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.0.4" PrivateAssets="all" />
     <PackageReference Include="NodaTime" Version="3.1.9" />
   </ItemGroup>

--- a/tests/TodoApp.Tests/TodoApp.Tests.csproj
+++ b/tests/TodoApp.Tests/TodoApp.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="JustEat.HttpClientInterception" Version="4.0.0" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.32.0" />
     <PackageReference Include="ReportGenerator" Version="5.1.19" />


### PR DESCRIPTION
Downgrade to the first .NET 7 release to test changes from v2.1.3 of update-dotnet-sdk.
