### PR TITLE
Add security label

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -35,7 +35,7 @@ permissions:
 # echo "Git user email: $(gh api "/users/${app_name}[bot]" --jq ".id")+${app_name}[bot]@users.noreply.github.com"
 jobs:
   update-sdk:
-    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@b2ed665ae5dd7e46b9557b059494c3022b8917f0 # v2.1.3
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@9881bbf5533bad92df886e6eb988e072a5612b12 # v2.1.4
     with:
       labels: "dependencies,.NET"
       user-email: ${{ vars.GIT_COMMIT_USER_EMAIL }}

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -43,3 +43,14 @@ jobs:
     secrets:
       application-id: ${{ secrets.UPDATER_APPLICATION_ID }}
       application-private-key: ${{ secrets.UPDATER_APPLICATION_PRIVATE_KEY }}
+
+  add-security-label:
+    name: Add security label
+    needs: update-sdk
+    runs-on: ubuntu-latest
+    if : |
+      needs.update-sdk.outputs.sdk-updated =='true' &&
+      needs.update-sdk.outputs.security == 'true'
+    steps:
+    - name: Add security label
+      run: gh pr edit "${{ needs.update-sdk.outputs.pull-request-html-url }}" --add-label security

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.203",
+    "version": "7.0.202",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/TodoApp/TodoApp.csproj
+++ b/src/TodoApp/TodoApp.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="7.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.4" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.0.4" PrivateAssets="all" />
     <PackageReference Include="NodaTime" Version="3.1.9" />
   </ItemGroup>

--- a/tests/TodoApp.Tests/TodoApp.Tests.csproj
+++ b/tests/TodoApp.Tests/TodoApp.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="JustEat.HttpClientInterception" Version="4.0.0" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.32.0" />
     <PackageReference Include="ReportGenerator" Version="5.1.19" />


### PR DESCRIPTION
- Add a `security` label to PRs when there's a security update.
- Use a commit with support for `Signed-off-by`.
- Downgrade to .NET 7.0.4 to test changes post-merge.