### PR TITLE
Trust additional dependencies

### DIFF
--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -36,7 +36,10 @@ jobs:
           contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/setup-dotnet') ||
           contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/setup-node') ||
           contains(steps.dependabot-metadata.outputs.dependency-names, 'dependabot/fetch-metadata') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'github/codeql-action')
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'github/codeql-action') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'Microsoft.NET.Test.Sdk') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'Microsoft.TypeScript.MSBuild') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'typescript')
         env:
           GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Add a number of Microsoft-published dependencies into the list that are automatically approved.
