### PR TITLE
Add note about GHES

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -32,7 +32,8 @@ permissions:
 # See https://docs.github.com/actions/learn-github-actions/variables.
 #
 # You can obtain the user name and email for the GitHub app by running the following command using the
-# GitHub CLI (https://cli.github.com/) in a terminal and substituting the values as shown below:
+# GitHub CLI (https://cli.github.com/) in a terminal and substituting the values as shown below.
+# If you're using GitHub Enterprise Server that the domain will be different and will need substituting.
 #
 # app_name="YOUR_GITHUB_APP_NAME"
 # echo "Git user name: ${app_name}[bot]"

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -33,7 +33,7 @@ permissions:
 #
 # You can obtain the user name and email for the GitHub app by running the following command using the
 # GitHub CLI (https://cli.github.com/) in a terminal and substituting the values as shown below.
-# If you're using GitHub Enterprise Server that the domain will be different and will need substituting.
+# If you're using GitHub Enterprise Server then the domain will be different and will need substituting.
 #
 # app_name="YOUR_GITHUB_APP_NAME"
 # echo "Git user name: ${app_name}[bot]"


### PR DESCRIPTION
Remind users to change the domain if using GitHub Enterprise Server rather than GitHub.com or GitHub Enterprise Cloud.
