### PR TITLE
Split out dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,11 @@ updates:
 - package-ecosystem: npm
   directory: "/src/TodoApp"
   groups:
-    dependencies:
+    babel:
       patterns:
         - "@babel/*"
+    typescript-eslint:
+      patterns:
         - "@typescript-eslint/*"
   schedule:
     day: monday


### PR DESCRIPTION
Have a group each for babel and typescript-eslint, rather than combining them.
