### PR TITLE
Harden for grouped dependencies

### DIFF
--- a/.github/workflows/approve-and-merge.yml
+++ b/.github/workflows/approve-and-merge.yml
@@ -37,7 +37,7 @@ jobs:
 
     # Only run for pull requests created by accounts we are interested in
     # that might be used to create a pull request to update the .NET SDK.
-    if: ${{ github.event.repository.fork == false && github.event.pull_request.user.login == vars.GIT_COMMIT_USER_NAME }}
+    if: github.event.repository.fork == false && github.event.pull_request.user.login == vars.GIT_COMMIT_USER_NAME
 
     steps:
 
@@ -57,7 +57,7 @@ jobs:
       id: check-dependencies
       env:
         # This list of trusted package prefixes needs to stay in sync with the list of package prefixes used by the update-dotnet-sdk workflow.
-        # See https://github.com/martincostello/update-dotnet-sdk/blob/131cefcd75229c796aee0044a6ceb2a2e0d39f9a/.github/workflows/update-dotnet-sdk.yml#L36-L40.
+        # See https://github.com/martincostello/update-dotnet-sdk/blob/69851254bcd31fdb36ae8a382c19573197980638/.github/workflows/update-dotnet-sdk.yml#L75-L79.
         INCLUDE_NUGET_PACKAGES: "Microsoft.AspNetCore.,Microsoft.EntityFrameworkCore.,Microsoft.Extensions.,System.Text.Json"
         GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
       shell: pwsh
@@ -134,7 +134,7 @@ jobs:
       # introduced by the update should be caught by the tests. If that happens, the build
       # workflow will fail and the preconditions for the auto-merge to happen won't be met.
     - name: Approve pull request and enable auto-merge
-      if: ${{ steps.check-dependencies.outputs.is-trusted-update == 'true' }}
+      if: steps.check-dependencies.outputs.is-trusted-update == 'true'
       env:
         GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
         PR_URL: ${{ github.event.pull_request.html_url }}
@@ -159,7 +159,7 @@ jobs:
     # automatically if there's an unexpected change introduced. Any existing review
     # approvals that were made by the bot are also dismissed so human approval is required.
     - name: Disable auto-merge and dismiss approvals
-      if: ${{ steps.check-dependencies.outputs.is-trusted-update != 'true' }}
+      if: steps.check-dependencies.outputs.is-trusted-update != 'true'
       env:
         GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
         PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-    - '**/*.gitattributes'
-    - '**/*.gitignore'
-    - '**/*.md'
+      - '**/*.gitattributes'
+      - '**/*.gitignore'
+      - '**/*.md'
   pull_request:
     branches:
       - main

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   code-ql:
     runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false }}
+    if: github.event.repository.fork == false
 
     permissions:
       security-events: write

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -29,17 +29,22 @@ jobs:
 
       - name: Approve pull request and enable auto-merge
         shell: bash
+        # Only approve pull requests if there is only exactly one dependency, and it is only of those listed below.
+        # If using grouped Dependabot updates, then you will need to update this condition to verify that all of
+        # the dependencies that were updated are ones that are trusted. Otherwise a group that contains a single
+        # trusted dependency amongst others that require manual review will be approved automatically.
+        # See https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/ for more information.
         if: |
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/cache') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/checkout') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/dependency-review-action') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/setup-dotnet') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/setup-node') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'dependabot/fetch-metadata') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'github/codeql-action') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'Microsoft.NET.Test.Sdk') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'Microsoft.TypeScript.MSBuild') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'typescript')
+          steps.dependabot-metadata.outputs.dependency-names == 'actions/cache' ||
+          steps.dependabot-metadata.outputs.dependency-names == 'actions/checkout' ||
+          steps.dependabot-metadata.outputs.dependency-names == 'actions/dependency-review-action' ||
+          steps.dependabot-metadata.outputs.dependency-names == 'actions/setup-dotnet' ||
+          steps.dependabot-metadata.outputs.dependency-names == 'actions/setup-node' ||
+          steps.dependabot-metadata.outputs.dependency-names == 'dependabot/fetch-metadata' ||
+          steps.dependabot-metadata.outputs.dependency-names == 'github/codeql-action' ||
+          steps.dependabot-metadata.outputs.dependency-names == 'Microsoft.NET.Test.Sdk' ||
+          steps.dependabot-metadata.outputs.dependency-names == 'Microsoft.TypeScript.MSBuild' ||
+          steps.dependabot-metadata.outputs.dependency-names == 'typescript'
         env:
           GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false && github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: github.event.repository.fork == false && github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false }}
+    if: github.event.repository.fork == false
 
     steps:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-    - '**/*.gitattributes'
-    - '**/*.gitignore'
-    - '**/*.md'
+      - '**/*.gitattributes'
+      - '**/*.gitignore'
+      - '**/*.md'
   pull_request:
     branches:
       - main

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: analysis
-    if: ${{ github.event.repository.fork == false }}
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -54,9 +54,7 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
-    if : |
-      needs.update-sdk.outputs.sdk-updated =='true' &&
-      needs.update-sdk.outputs.security == 'true'
+    if: needs.update-sdk.outputs.sdk-updated =='true' && needs.update-sdk.outputs.security == 'true'
     steps:
     - name: Add security label
       env:


### PR DESCRIPTION
Harden the condition for approving a Dependabot pull request against [grouped dependency updates](https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/) that might contain a mix of approved and not-approved dependencies in a single pull request.

Also some minor workflow refactoring/tidying-up.
