### PR TITLE
Remove MSBUILDTERMINALLOGGER

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -12,10 +12,6 @@ $Configuration = "Release"
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-if ($null -eq $env:MSBUILDTERMINALLOGGER) {
-    $env:MSBUILDTERMINALLOGGER = "auto"
-}
-
 $solutionPath = $PSScriptRoot
 $sdkFile = Join-Path $solutionPath "global.json"
 


### PR DESCRIPTION
Remove redundant usage of `MSBUILDTERMINALLOGGER`.
