### PR TITLE
Add SDK hint paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.dotnetcli
+.dotnet
 .DS_Store
 .idea
 .metadata

--- a/build.ps1
+++ b/build.ps1
@@ -43,7 +43,7 @@ else {
 
 if ($installDotNetSdk -eq $true) {
 
-    $env:DOTNET_INSTALL_DIR = Join-Path $PSScriptRoot ".dotnetcli"
+    $env:DOTNET_INSTALL_DIR = Join-Path $PSScriptRoot ".dotnet"
     $sdkPath = Join-Path $env:DOTNET_INSTALL_DIR "sdk" "$dotnetVersion"
 
     if (!(Test-Path $sdkPath)) {

--- a/global.json
+++ b/global.json
@@ -2,6 +2,8 @@
   "sdk": {
     "version": "9.0.202",
     "allowPrerelease": false,
-    "rollForward": "latestMajor"
+    "rollForward": "latestMajor",
+    "paths": [ ".dotnet", "$host$" ],
+    "errorMessage": "The required version of the .NET SDK could not be found. Please run ./build.ps1 to bootstrap the .NET SDK."
   }
 }

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -11,7 +11,7 @@
     "enableEditorConfigSupport": true
   },
   "msbuild": {
-    "MSBuildSDKsPath": ".\\.dotnetcli",
+    "MSBuildSDKsPath": ".\\.dotnet",
     "EnablePackageAutoRestore": true,
     "loadProjectsOnDemand": true
   },

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -4,8 +4,8 @@ SETLOCAL
 :: This command launches a Visual Studio solution with environment variables required to use a local version of the .NET SDK.
 
 :: This tells .NET to use the same dotnet.exe that the build script uses.
-SET DOTNET_ROOT=%~dp0.dotnetcli
-SET DOTNET_ROOT(x86)=%~dp0.dotnetcli\x86
+SET DOTNET_ROOT=%~dp0.dotnet
+SET DOTNET_ROOT(x86)=%~dp0.dotnet\x86
 
 :: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use.
 SET PATH=%DOTNET_ROOT%;%PATH%

--- a/startvscode.cmd
+++ b/startvscode.cmd
@@ -4,8 +4,8 @@ SETLOCAL
 :: This command launches Visual Studio Code with environment variables required to use a local version of the .NET SDK.
 
 :: This tells .NET to use the same dotnet.exe that the build script uses.
-SET DOTNET_ROOT=%~dp0.dotnetcli
-SET DOTNET_ROOT(x86)=%~dp0.dotnetcli\x86
+SET DOTNET_ROOT=%~dp0.dotnet
+SET DOTNET_ROOT(x86)=%~dp0.dotnet\x86
 
 :: Put our local dotnet.exe on PATH first so Visual Studio Code knows which one to use.
 SET PATH=%DOTNET_ROOT%;%PATH%


### PR DESCRIPTION
- Add new .NET 10 properties for locating the .NET SDK.
- Move from `.dotnetcli` to `.dotnet`.
