### PR TITLE
Simplify code

### DIFF
--- a/tests/TodoApp.Tests/ApiTests.cs
+++ b/tests/TodoApp.Tests/ApiTests.cs
@@ -259,8 +259,7 @@ public class ApiTests
 
         var client = Fixture.CreateClient(options);
 
-        var parameters = Array.Empty<KeyValuePair<string?, string?>>();
-        using var content = new FormUrlEncodedContent(parameters);
+        using var content = new FormUrlEncodedContent([]);
 
         // Go through the sign-in flow, which will set
         // the authentication cookie on the HttpClient.


### PR DESCRIPTION
Use collection expression for empty parameters for `FormUrlEncodedContent`.
