### PR TITLE
Update deprecated action input

### DIFF
--- a/.github/workflows/approve-and-merge.yml
+++ b/.github/workflows/approve-and-merge.yml
@@ -50,7 +50,7 @@ jobs:
       id: generate-application-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.REVIEWER_APPLICATION_ID }}
+        client-id: ${{ secrets.REVIEWER_APPLICATION_ID }}
         private-key: ${{ secrets.REVIEWER_APPLICATION_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -22,7 +22,7 @@ jobs:
         id: generate-application-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.REVIEWER_APPLICATION_ID }}
+          client-id: ${{ secrets.REVIEWER_APPLICATION_ID }}
           private-key: ${{ secrets.REVIEWER_APPLICATION_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
`app-id` was deprecated in 3.1.0 in favour of `client-id`.
