### PR TITLE
Fix CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,4 +23,8 @@
   <ItemGroup>
     <Using Include="System.Globalization" />
   </ItemGroup>
+  <!-- HACK Workaround until fix from https://github.com/dotnet/efcore/pull/38402 is available -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Suppress GHSA-2m69-gcr7-jv3q until a patched version of EFCore is available.
